### PR TITLE
FIX: Update CircleCI MySQL image to next-generation image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
           - SS_DATABASE_PASSWORD=ubuntu
           - SS_DATABASE_NAME=circle_test
           - SS_ENVIRONMENT_TYPE=dev
-      - image: circleci/mysql:5.7
+      - image: cimg/mysql:5.7
         environment:
           - MYSQL_USER=root
           - MYSQL_ROOT_PASSWORD=ubuntu


### PR DESCRIPTION
As per CirleCI's recommendation we should update the MySQL image to use a next-generation image as the old one will be deprecated. Context: https://circleci.com/docs/2.0/circleci-images/